### PR TITLE
feat: virtual FPP test environment + repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,173 @@
-To see how to use these files, check out the [Remote Falcon Developer Docs](https://docs.remotefalcon.com/docs/developer-docs/welcome).
+# developer-files
+
+Tooling and reference configurations for Remote Falcon developers and
+operators. Stuff that doesn't belong in any single service repo lives
+here: docker-compose stacks, deployment scripts, test environments,
+and standalone utilities.
+
+## Contents
+
+| Directory / file | Purpose |
+|---|---|
+| [`fpp-test-env/`](./fpp-test-env) | Virtual FPP environment for plugin development. Boots the official `falconchristmas/fpp` Docker image alongside a configurable mock Remote Falcon API so plugin authors can install, exercise, and assert against a plugin without touching hardware or hitting the production RF backend. |
+| [`local-docker-compose/`](./local-docker-compose) | Single docker-compose stack that runs the entire Remote Falcon platform locally (Mongo, plugins-api, control-panel, viewer, gateway, UI, etc.). For end-to-end backend development. See the [Local Development guide](https://docs.remotefalcon.com/docs/developer-docs/welcome) on the docs site for setup. |
+| [`do-ubuntu-droplet/`](./do-ubuntu-droplet) | Scripts and configs for spinning up the full RF stack on a DigitalOcean Ubuntu droplet: `docker-install.sh`, `nginx-config.sh`, `start-rf.sh`, `stop-rf.sh`, `restart-rf.sh`, plus the corresponding `docker-compose.yaml` and nginx `default.conf`. See the docs site for the full walkthrough. |
+| [`rf-volume-control.php`](./rf-volume-control.php) | Standalone helper that watches FPP playback and toggles audio volume between a "request playing" level and a "normal scheduled" level. Drop it on an FPP host and run it as a long-lived process if your show needs different volumes for viewer-driven sequences. |
+
+For most of the above (other than `fpp-test-env`, which is new), the
+authoritative usage docs live at the [Remote Falcon Developer Docs](https://docs.remotefalcon.com/docs/developer-docs/welcome).
+
+---
+
+## fpp-test-env — virtual FPP for plugin testing
+
+A complete plugin development environment that runs entirely in Docker.
+Pairs the official FPP image with a mock Remote Falcon plugins API so
+plugin code can be installed, started, and asserted against without
+real hardware and without a real RF account.
+
+**See [`fpp-test-env/README.md`](./fpp-test-env/README.md) for full
+documentation.** What follows is a quick orientation.
+
+### What you get
+
+- **Real FPP** — the upstream `falconchristmas/fpp:9.5.3` image.
+  Real FPPD daemon, real apache + php-fpm, real plugin manager.
+  Hardware-dependent features (GPIO, USB pixel drivers, real audio
+  output) don't work; everything else does.
+- **Mock Remote Falcon API** — a small `php -S` server with sensible
+  no-op success defaults for every plugin-API endpoint, configurable
+  per-route via JSON, with full request recording so smoke tests can
+  assert on what the plugin called.
+- **First-run wizard pre-bypassed** — every spin-up sets the
+  `initialSetup` flags so you land directly on the FPP main page
+  instead of clicking through the onboarding interstitial.
+- **Orchestration scripts** — bring the env up, install a plugin,
+  seed plugin config, start the listener, run a smoke script, tear
+  down.
+
+### Requirements
+
+- Docker (29+ tested)
+- `bash`, `curl`, `python3`
+
+### Quickstart
+
+```bash
+cd fpp-test-env
+
+# Bring up FPP + mock RF. ~5s on cached image, ~90s first run.
+./scripts/spin-up.sh
+
+# Install the plugin you want to test from a host source dir.
+./scripts/install-plugin.sh ~/path/to/your-plugin your-plugin-name
+
+# Seed plugin settings. Values are urlencoded into
+# /home/fpp/media/config/plugin.<name> inside the container.
+./scripts/seed-config.sh your-plugin-name \
+    remoteToken=test-token \
+    pluginsApiPath=http://mock-rf-api \
+    remoteFalconListenerEnabled=true
+
+# Start the plugin's listener (if it has one).
+./scripts/start-listener.sh your-plugin-name
+
+# Browser at http://127.0.0.1:18080 — full FPP web UI is now
+# clickable. Plugin appears in the FPP plugin manager.
+
+# Run a plugin-side smoke script (optional, plugin-defined).
+./scripts/smoke-test.sh ~/path/to/your-plugin/tests/virtual-fpp/smoke.sh
+
+# When done.
+./scripts/tear-down.sh
+```
+
+### URLs the harness exposes
+
+| URL | What it is |
+|---|---|
+| `http://127.0.0.1:18080` | FPP web UI and API on the host |
+| `http://127.0.0.1:18081` | Mock RF API on the host (for sanity checks) |
+| `http://mock-rf-api` (in-container) | Mock RF API as the listener sees it |
+
+### Configuring mock RF responses
+
+The mock reads route config from `fpp-test-env/.state/config.json`
+on every request and appends every received request to
+`fpp-test-env/.state/recordings.json`. Smoke scripts (and you, when
+exploring interactively) can rewrite the config to simulate any
+backend response:
+
+```bash
+# Make the mock return a "winning vote" so the plugin queues a sequence.
+cat > fpp-test-env/.state/config.json <<EOF
+{
+  "/highestVotedPlaylist": {
+    "body": {"winningPlaylist": "happy.fseq", "playlistIndex": 1}
+  }
+}
+EOF
+
+# Watch the listener pick it up.
+docker exec rf-test-fpp tail -f /home/fpp/media/logs/your-plugin-listener.log
+```
+
+Route config supports `body` (string/array/object), `status` (HTTP
+code, default 200), `contentType` (default `application/json`),
+`delayMs` (for testing timeout behavior), and `*`-suffix path
+patterns for prefix matching. Endpoints not in the config get
+sensible defaults — see [`fpp-test-env/mock-rf-api/router.php`](./fpp-test-env/mock-rf-api/router.php).
+
+### Smoke script contract
+
+Plugin-side smoke scripts are owned by the plugin repo, not this
+harness. `scripts/smoke-test.sh` invokes the script with these env
+vars populated:
+
+| Variable | Value |
+|---|---|
+| `FPP_BASE_URL` | `http://127.0.0.1:18080` |
+| `FPP_CONTAINER` | `rf-test-fpp` |
+| `MOCK_RF_BASE_URL` | `http://127.0.0.1:18081` (host-side) |
+| `MOCK_RF_INTERNAL_URL` | `http://mock-rf-api` (in-container) |
+| `MOCK_RF_STATE_DIR` | absolute path to `.state/` |
+
+Smoke scripts should `set -e`, exit 0 on success, and return a
+non-zero status on failure. Plain bash + `curl` + `jq` is a fine
+toolchain; no test framework required.
+
+### Caveats
+
+- The upstream FPP project explicitly marks the Docker image as
+  developer-only ("only a subset of FPP features work under docker").
+  For our use case (plugin install, listener startup, FPP web API
+  integration testing) that subset is sufficient; for hardware-driven
+  features it is not.
+- The harness intentionally does **not** install plugins via FPP's
+  plugin manager API (which would clone from GitHub). Instead it
+  `docker cp`s the local source tree into the container so you can
+  iterate on uncommitted local changes.
+- First-run pulls the FPP image (~830 MB). Cached spin-ups drop to
+  ~5–15 s.
+- Each spin-up boots a fresh FPP. State (settings, playlists, plugin
+  data) does not persist across `tear-down.sh` → `spin-up.sh` cycles.
+  If you want it to, mount a host directory to `/home/fpp/media`
+  in `fpp-test-env/docker-compose.yaml`.
+
+### Troubleshooting
+
+- **Port 18080 or 18081 already in use** — free the port or edit the
+  host-port mappings in `fpp-test-env/docker-compose.yaml`.
+- **`WriteSettingToFile` flock errors** — usually means a config file
+  ended up root-owned. Re-run `chown -R fpp:fpp` on the plugin dir
+  inside the container, or just `tear-down.sh && spin-up.sh` for a
+  clean state.
+- **FPP won't start** — check `docker compose logs fpp` from
+  `fpp-test-env/`. Mid-build kills can leave a half-baked container;
+  tear down and retry.
+
+---
+
+## License
+
+See [`LICENSE`](./LICENSE).

--- a/fpp-test-env/.gitignore
+++ b/fpp-test-env/.gitignore
@@ -1,0 +1,2 @@
+# Per-run state (mock RF API config + request recordings).
+.state/

--- a/fpp-test-env/README.md
+++ b/fpp-test-env/README.md
@@ -1,0 +1,158 @@
+# fpp-test-env
+
+A virtual FPP environment for plugin development. Spins up a real FPP
+container alongside a configurable mock Remote Falcon API so plugins can
+be installed, exercised, and asserted against without touching real
+hardware or hitting the production RF backend.
+
+## What's in the box
+
+- **`falconchristmas/fpp:9.5.3`** — the official FPP Docker image
+  ([source](https://github.com/FalconChristmas/fpp/blob/master/Docker/Dockerfile)).
+  Real FPPD daemon, real apache + php-fpm, real plugin manager.
+- **Mock RF API** (`mock-rf-api/router.php`) — a tiny `php -S` server that
+  returns canned responses for `/remotePreferences`, `/highestVotedPlaylist`,
+  `/nextPlaylistInQueue`, `/updateWhatsPlaying`, `/updateNextScheduledSequence`,
+  `/q/health`, `/syncPlaylists`, `/purgeQueue`, etc. Defaults are no-op
+  successful responses; tests override per-route via JSON config.
+- **Orchestration scripts** — bring the env up, install a plugin, seed
+  plugin config, run a plugin-specific smoke script, tear down.
+
+## Requirements
+
+- Docker (tested with Docker 29+).
+- `bash`, `curl`, `python3` (for sanity checks).
+- The plugin you want to test, checked out somewhere on your host.
+
+## Quickstart
+
+```bash
+cd developer-files/fpp-test-env
+
+# Bring up FPP + mock RF API. ~5s on cached image, ~90s first run.
+./scripts/spin-up.sh
+
+# Install a plugin from a host source directory.
+./scripts/install-plugin.sh ~/rf-build/remote-falcon-plugin remote-falcon
+
+# Seed plugin settings. The values are urlencoded and written to
+# /home/fpp/media/config/plugin.<name> inside the container, mimicking
+# what FPP's WriteSettingToFile would do.
+./scripts/seed-config.sh remote-falcon \
+    remoteToken=test-token-xyz \
+    pluginsApiPath=http://mock-rf-api \
+    remotePlaylist=TestPlaylist \
+    remoteFalconListenerEnabled=true \
+    remoteFalconListenerRestarting=false \
+    interruptSchedule=false \
+    requestFetchTime=3 \
+    additionalWaitTime=0 \
+    fppStatusCheckTime=1 \
+    verboseLogging=true
+
+# Start the listener. (Plugin-specific; the harness doesn't assume
+# every plugin has a long-running listener.)
+docker exec rf-test-fpp /home/fpp/media/plugins/remote-falcon/scripts/postStart.sh
+
+# Run a plugin-specific smoke script.
+./scripts/smoke-test.sh ~/rf-build/remote-falcon-plugin/tests/virtual-fpp/smoke.sh
+
+# When done.
+./scripts/tear-down.sh
+```
+
+## What the harness exposes
+
+| URL / path | Purpose |
+|---|---|
+| `http://127.0.0.1:18080` | FPP web UI and API on the host |
+| `http://127.0.0.1:18081` | Mock RF API on the host (for sanity checks) |
+| `http://mock-rf-api` | Mock RF API as the listener sees it (in-network) |
+| `.state/config.json` | Mock RF route config; smoke scripts write this |
+| `.state/recordings.json` | Every request the mock received; smoke scripts read this |
+
+The state directory is recreated on each `spin-up.sh` and removed by
+`tear-down.sh`.
+
+## Configuring mock RF responses from a smoke script
+
+The mock reads route config from `.state/config.json` on every request, so
+smoke scripts can change responses mid-run by rewriting that file. Example:
+
+```bash
+STATE="$MOCK_RF_STATE_DIR"
+
+# Make the mock return a specific winning sequence.
+cat > "$STATE/config.json" <<EOF
+{
+  "/highestVotedPlaylist": {
+    "body": {"winningPlaylist": "happy.fseq", "playlistIndex": 7}
+  }
+}
+EOF
+
+# Trigger the listener... (e.g., create a playlist with seconds_remaining<3)
+
+# Read what the listener sent back.
+cat "$STATE/recordings.json" | python3 -m json.tool
+```
+
+Route config supports:
+- `body` — string, array, or object. Arrays/objects are JSON-encoded.
+- `status` — HTTP status code (default 200).
+- `contentType` — Content-Type header (default `application/json`).
+- `delayMs` — sleep before responding (for timeout testing).
+- Path patterns ending in `*` match prefix.
+
+Endpoints not in the config get sensible defaults (see `mock-rf-api/router.php`).
+
+## Smoke script conventions
+
+Smoke scripts are owned by the plugin repo, not the harness. They receive
+these env vars from `smoke-test.sh`:
+
+| Variable | Value |
+|---|---|
+| `FPP_BASE_URL` | `http://127.0.0.1:18080` |
+| `FPP_CONTAINER` | `rf-test-fpp` |
+| `MOCK_RF_BASE_URL` | `http://127.0.0.1:18081` (host-side) |
+| `MOCK_RF_INTERNAL_URL` | `http://mock-rf-api` (in-container, for the listener) |
+| `MOCK_RF_STATE_DIR` | absolute path to the harness's `.state/` |
+
+A smoke script should `set -e`, exit 0 on success, and any non-zero on
+failure. The harness is intentionally agnostic about test framework;
+plain bash + `curl` + `jq` works fine.
+
+## Caveats
+
+- The Docker image is community-maintained by FPP itself but is explicitly
+  marked as developer-only by upstream — "only a subset of FPP features
+  work under docker." Hardware-dependent features (GPIO, USB pixel
+  drivers, real audio output) won't work in this environment. For our
+  use case (plugin install + listener startup + API integration testing)
+  that subset is sufficient.
+- The harness intentionally does NOT install the plugin via FPP's plugin
+  manager API (which would clone from GitHub). Instead it `docker cp`s
+  the local source tree into `/home/fpp/media/plugins/<name>/` so you
+  can iterate on uncommitted local changes.
+- `seed-config.sh` writes the INI directly. If your plugin's listener
+  runs setup logic that depends on FPP's `WriteSettingToFile` having
+  populated the config, that will run on first listener start.
+- First-run pulls the FPP image (~830 MB). Cached runs reuse the
+  pulled layers; spin-up drops to ~5–15 s.
+
+## Troubleshooting
+
+**FPP won't start.** Run `docker compose logs fpp` from this directory.
+The image's `runDocker.sh` builds FPP source on first start; if the
+container is killed mid-build it can leave a half-baked state. Tear
+down with `./scripts/tear-down.sh -v` and try again.
+
+**`WriteSettingToFile` fails with `flock()` error.** The plugin config
+file is owned by root (because we copied it in via `docker cp` as root).
+`install-plugin.sh` chowns the plugin tree to `fpp:fpp` after copy, but
+if you wrote files via `docker exec ... > file` they may end up
+root-owned. Re-run `chown -R fpp:fpp` on the plugin dir.
+
+**Port 18080 or 18081 already in use.** Either free the port or edit
+the host-port mappings in `docker-compose.yaml`.

--- a/fpp-test-env/docker-compose.yaml
+++ b/fpp-test-env/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  fpp:
+    container_name: rf-test-fpp
+    image: falconchristmas/fpp:9.5.3
+    hostname: rf-test-fpp
+    ports:
+      # Expose FPP web UI on a high port to avoid colliding with anything
+      # the host machine might already be running on :80 or :8080.
+      - "127.0.0.1:18080:80/tcp"
+    environment:
+      - TZ=UTC
+    cap_add:
+      - SYS_PTRACE
+      - SYS_NICE
+    networks:
+      - rf-test-net
+
+  mock-rf-api:
+    container_name: rf-test-mock-rf-api
+    image: php:8.3-cli
+    hostname: mock-rf-api
+    working_dir: /app
+    volumes:
+      - ./mock-rf-api:/app:ro
+      # Tests write route config + read request recordings via this volume.
+      # The harness scripts on the host create/clear these files between runs.
+      - ./.state:/state
+    environment:
+      - RF_MOCK_CONFIG=/state/config.json
+      - RF_MOCK_RECORDINGS=/state/recordings.json
+    command: ["php", "-S", "0.0.0.0:80", "/app/router.php"]
+    ports:
+      # Also expose the mock to the host so harness scripts can hit it
+      # directly for sanity checks (curl http://localhost:18081/q/health).
+      - "127.0.0.1:18081:80/tcp"
+    networks:
+      - rf-test-net
+
+networks:
+  rf-test-net:
+    name: rf-test-net

--- a/fpp-test-env/mock-rf-api/router.php
+++ b/fpp-test-env/mock-rf-api/router.php
@@ -1,0 +1,117 @@
+<?php
+// Mock Remote Falcon plugins API for the virtual-FPP test harness.
+// Invoked by `php -S` from spin-up.sh.
+//
+// Routes are configured by writing JSON to the file at $RF_MOCK_CONFIG.
+// Every incoming request is appended to $RF_MOCK_RECORDINGS so smoke
+// scripts can assert on what the plugin called.
+//
+// This is intentionally a sibling to remote-falcon-plugin's
+// tests/integration/router.php — same shape, same env-var contract,
+// reused so contributors only have to learn the pattern once.
+
+$configPath = getenv('RF_MOCK_CONFIG') ?: '/tmp/rf-mock.config.json';
+$recordingsPath = getenv('RF_MOCK_RECORDINGS') ?: '/tmp/rf-mock.recordings.json';
+
+$config = [];
+if (is_file($configPath)) {
+    $raw = file_get_contents($configPath);
+    if ($raw !== false) {
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            $config = $decoded;
+        }
+    }
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+$rawPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$path = rawurldecode($rawPath);
+$query = $_SERVER['QUERY_STRING'] ?? '';
+
+$headers = [];
+foreach ($_SERVER as $k => $v) {
+    if (strpos($k, 'HTTP_') === 0) {
+        $name = strtolower(str_replace('_', '-', substr($k, 5)));
+        $headers[$name] = $v;
+    }
+}
+
+$requestBody = file_get_contents('php://input');
+
+$recordings = [];
+if (is_file($recordingsPath)) {
+    $raw = file_get_contents($recordingsPath);
+    if ($raw !== false) {
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            $recordings = $decoded;
+        }
+    }
+}
+$recordings[] = [
+    'method' => $method,
+    'path' => $path,
+    'query' => $query,
+    'headers' => $headers,
+    'body' => $requestBody,
+    'timestamp' => microtime(true),
+];
+file_put_contents($recordingsPath, json_encode($recordings));
+
+// Default routes for endpoints commonly hit during a smoke. Tests can
+// override these via setRoute in the config file.
+$defaults = [
+    '/q/health' => ['body' => ['status' => 'UP']],
+    '/remotePreferences' => ['body' => ['viewerControlMode' => 'jukebox']],
+    '/highestVotedPlaylist' => ['body' => ['winningPlaylist' => null, 'playlistIndex' => null]],
+    '/nextPlaylistInQueue' => ['body' => ['nextPlaylist' => null, 'playlistIndex' => null]],
+    '/updateWhatsPlaying' => ['body' => ['ok' => true]],
+    '/updateNextScheduledSequence' => ['body' => ['ok' => true]],
+    '/fppHeartbeat' => ['body' => ['ok' => true]],
+    '/pluginVersion' => ['body' => ['ok' => true]],
+    '/syncPlaylists' => ['body' => ['ok' => true]],
+    '/purgeQueue' => ['body' => ['ok' => true]],
+    '/updateViewerControl' => ['body' => ['ok' => true]],
+    '/updateManagedPsa' => ['body' => ['ok' => true]],
+];
+
+$route = null;
+if (isset($config[$path])) {
+    $route = $config[$path];
+} else {
+    foreach ($config as $pattern => $cfg) {
+        if (substr($pattern, -1) === '*') {
+            $prefix = substr($pattern, 0, -1);
+            if (strpos($path, $prefix) === 0) {
+                $route = $cfg;
+                break;
+            }
+        }
+    }
+}
+if ($route === null && isset($defaults[$path])) {
+    $route = $defaults[$path];
+}
+
+if ($route === null) {
+    http_response_code(404);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'no route configured', 'path' => $path]);
+    return;
+}
+
+$delayMs = $route['delayMs'] ?? 0;
+if ($delayMs > 0) {
+    usleep((int) ($delayMs * 1000));
+}
+
+http_response_code($route['status'] ?? 200);
+header('Content-Type: ' . ($route['contentType'] ?? 'application/json'));
+
+$body = $route['body'] ?? '';
+if (is_array($body) || is_object($body)) {
+    echo json_encode($body);
+} else {
+    echo $body;
+}

--- a/fpp-test-env/scripts/install-plugin.sh
+++ b/fpp-test-env/scripts/install-plugin.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copy a plugin source directory into the running FPP container as if FPP
+# had cloned it from GitHub, then run the plugin's fpp_install.sh.
+#
+# Usage: install-plugin.sh PLUGIN_SOURCE_DIR [PLUGIN_NAME]
+#   PLUGIN_SOURCE_DIR   Path to the plugin's repo on the host
+#   PLUGIN_NAME         Optional; defaults to the basename of PLUGIN_SOURCE_DIR
+
+set -euo pipefail
+
+if [ "${1-}" = "" ]; then
+    echo "usage: $0 PLUGIN_SOURCE_DIR [PLUGIN_NAME]" >&2
+    exit 1
+fi
+
+PLUGIN_SOURCE="$(cd "$1" && pwd)"
+PLUGIN_NAME="${2:-$(basename "$PLUGIN_SOURCE")}"
+CONTAINER="rf-test-fpp"
+DEST="/home/fpp/media/plugins/${PLUGIN_NAME}"
+
+if ! docker ps --filter "name=^${CONTAINER}$" --format '{{.Names}}' | grep -q "$CONTAINER"; then
+    echo "Container $CONTAINER is not running. Run scripts/spin-up.sh first." >&2
+    exit 1
+fi
+
+echo "Installing $PLUGIN_NAME from $PLUGIN_SOURCE into $CONTAINER:$DEST"
+
+# Make sure the plugins parent dir exists.
+docker exec "$CONTAINER" mkdir -p /home/fpp/media/plugins
+
+# Wipe any prior copy so this is a clean install.
+docker exec "$CONTAINER" rm -rf "$DEST"
+
+# Copy the source tree in. docker cp on a directory creates the dest dir.
+docker cp "$PLUGIN_SOURCE/." "$CONTAINER:$DEST"
+
+# Files copied via `docker cp` end up owned by root. FPP's web API expects
+# fpp:fpp ownership for the plugin config file (otherwise WriteSettingToFile
+# fails an flock check). Chown the whole tree.
+docker exec "$CONTAINER" chown -R fpp:fpp "$DEST"
+
+# Run the plugin's fpp_install.sh if present. This mirrors what FPP does
+# after a real `git clone` of the plugin.
+if docker exec "$CONTAINER" test -x "$DEST/scripts/fpp_install.sh"; then
+    echo "Running $PLUGIN_NAME/scripts/fpp_install.sh..."
+    docker exec -e FPPDIR=/opt/fpp "$CONTAINER" "$DEST/scripts/fpp_install.sh"
+fi
+
+# Confirm FPP's plugin manager sees it.
+echo ""
+echo "Installed plugins:"
+curl -sf http://127.0.0.1:18080/api/plugin
+echo ""

--- a/fpp-test-env/scripts/seed-config.sh
+++ b/fpp-test-env/scripts/seed-config.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Write a plugin's INI config file directly inside the running FPP container,
+# bypassing the FPP web API. Used to seed test configuration with values like
+# the mock RF API URL and a fake show token before starting the listener.
+#
+# Usage: seed-config.sh PLUGIN_NAME KEY=VALUE [KEY=VALUE ...]
+#
+# Values may include URL-unsafe characters; they will be urlencoded before
+# being written, matching what WriteSettingToFile does in FPP's common.php.
+
+set -euo pipefail
+
+if [ "${1-}" = "" ] || [ "${2-}" = "" ]; then
+    cat >&2 <<EOF
+usage: $0 PLUGIN_NAME KEY=VALUE [KEY=VALUE ...]
+
+example:
+  $0 remote-falcon \\
+     remoteToken=test-token-123 \\
+     pluginsApiPath=http://mock-rf-api/ \\
+     remotePlaylist=TestPlaylist \\
+     remoteFalconListenerEnabled=true
+EOF
+    exit 1
+fi
+
+PLUGIN_NAME="$1"
+shift
+CONTAINER="rf-test-fpp"
+CONFIG_PATH="/home/fpp/media/config/plugin.${PLUGIN_NAME}"
+
+if ! docker ps --filter "name=^${CONTAINER}$" --format '{{.Names}}' | grep -q "$CONTAINER"; then
+    echo "Container $CONTAINER is not running. Run scripts/spin-up.sh first." >&2
+    exit 1
+fi
+
+# Generate the INI inside the container so urlencoding uses the same PHP
+# semantics as WriteSettingToFile would.
+PHP_PROG='
+$path = $_SERVER["argv"][1];
+array_shift($_SERVER["argv"]); array_shift($_SERVER["argv"]);
+$existing = is_file($path) ? (parse_ini_file($path) ?: []) : [];
+foreach ($_SERVER["argv"] as $kv) {
+    [$k, $v] = explode("=", $kv, 2) + [null, null];
+    if ($k === null) continue;
+    $existing[$k] = urlencode($v);
+}
+$out = "";
+foreach ($existing as $k => $v) {
+    $out .= sprintf("%s = \"%s\"\n", $k, $v);
+}
+file_put_contents($path, $out);
+chown($path, "fpp");
+chgrp($path, "fpp");
+chmod($path, 0664);
+'
+
+docker exec "$CONTAINER" mkdir -p /home/fpp/media/config
+docker exec "$CONTAINER" php -r "$PHP_PROG" "$CONFIG_PATH" "$@"
+
+echo "Seeded $CONFIG_PATH with $#  setting(s)."
+echo "---"
+docker exec "$CONTAINER" cat "$CONFIG_PATH"

--- a/fpp-test-env/scripts/smoke-test.sh
+++ b/fpp-test-env/scripts/smoke-test.sh
@@ -19,11 +19,19 @@ if [ "${1-}" = "" ]; then
     exit 1
 fi
 
+if [ ! -f "$1" ]; then
+    echo "smoke script not found: $1" >&2
+    echo "(if you checked out a plugin branch that doesn't include tests/virtual-fpp/smoke.sh," >&2
+    echo " switch to a branch that has it, e.g. chore/virtual-fpp-smoke)" >&2
+    exit 1
+fi
+
 SMOKE="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 HARNESS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 if [ ! -x "$SMOKE" ]; then
-    echo "$SMOKE is not executable" >&2
+    echo "smoke script exists but is not executable: $SMOKE" >&2
+    echo "fix with: chmod +x $SMOKE" >&2
     exit 1
 fi
 

--- a/fpp-test-env/scripts/smoke-test.sh
+++ b/fpp-test-env/scripts/smoke-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run a plugin-specific smoke script with the harness environment populated.
+# The harness owns FPP + mock RF; the smoke script owns plugin-specific
+# assertions about how the plugin behaves once installed.
+#
+# Usage: smoke-test.sh PATH_TO_SMOKE_SCRIPT
+#
+# The smoke script receives these env vars:
+#   FPP_BASE_URL          http://127.0.0.1:18080
+#   FPP_CONTAINER         rf-test-fpp
+#   MOCK_RF_BASE_URL      http://127.0.0.1:18081  (host-side)
+#   MOCK_RF_INTERNAL_URL  http://mock-rf-api      (in-container, for the listener)
+#   MOCK_RF_STATE_DIR     absolute path to .state on the host
+
+set -euo pipefail
+
+if [ "${1-}" = "" ]; then
+    echo "usage: $0 PATH_TO_SMOKE_SCRIPT" >&2
+    exit 1
+fi
+
+SMOKE="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+HARNESS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ ! -x "$SMOKE" ]; then
+    echo "$SMOKE is not executable" >&2
+    exit 1
+fi
+
+export FPP_BASE_URL="http://127.0.0.1:18080"
+export FPP_CONTAINER="rf-test-fpp"
+export MOCK_RF_BASE_URL="http://127.0.0.1:18081"
+export MOCK_RF_INTERNAL_URL="http://mock-rf-api"
+export MOCK_RF_STATE_DIR="$HARNESS_DIR/.state"
+
+echo "Running smoke: $SMOKE"
+echo "  FPP:           $FPP_BASE_URL"
+echo "  Mock RF (host):$MOCK_RF_BASE_URL"
+echo "  Mock RF (FPP): $MOCK_RF_INTERNAL_URL"
+echo ""
+
+"$SMOKE"

--- a/fpp-test-env/scripts/spin-up.sh
+++ b/fpp-test-env/scripts/spin-up.sh
@@ -45,6 +45,18 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
+# Skip FPP's first-run setup wizard so the UI is immediately navigable.
+# Without these flags, opening http://127.0.0.1:18080 lands on a "Finish
+# Setup" interstitial that has to be clicked through (and is flaky to
+# dismiss). Each spin-up boots a fresh FPP, so we set these every time.
+for key in initialSetup initialSetup-01 initialSetup-02; do
+    curl -sf -X PUT \
+        -H 'Content-Type: text/plain' \
+        --data '1' \
+        "http://127.0.0.1:18080/api/settings/${key}" >/dev/null
+done
+echo "First-run setup wizard bypassed (initialSetup flags set)."
+
 echo ""
 echo "Environment ready:"
 echo "  FPP web UI / API:    http://127.0.0.1:18080"

--- a/fpp-test-env/scripts/spin-up.sh
+++ b/fpp-test-env/scripts/spin-up.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bring up the virtual FPP + mock RF API and wait until both are healthy.
+# Idempotent: safe to run repeatedly; prior containers are removed first.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$HERE"
+
+# Reset state directory used by the mock RF API for route config + recordings.
+rm -rf "$HERE/.state"
+mkdir -p "$HERE/.state"
+echo '{}' > "$HERE/.state/config.json"
+echo '[]' > "$HERE/.state/recordings.json"
+
+# Tear down any stale containers from a previous run, then bring up fresh.
+docker compose down -v --remove-orphans >/dev/null 2>&1 || true
+docker compose up -d
+
+echo "Waiting for FPP API to respond..."
+for i in $(seq 1 60); do
+    if curl -sf -o /dev/null http://127.0.0.1:18080/api/system/status; then
+        echo "FPP ready after ${i}s"
+        break
+    fi
+    if [ "$i" = "60" ]; then
+        echo "FPP failed to come up in 60s; container logs:" >&2
+        docker compose logs fpp >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "Waiting for mock RF API..."
+for i in $(seq 1 30); do
+    if curl -sf -o /dev/null http://127.0.0.1:18081/q/health; then
+        echo "Mock RF API ready after ${i}s"
+        break
+    fi
+    if [ "$i" = "30" ]; then
+        echo "Mock RF API failed to come up in 30s; container logs:" >&2
+        docker compose logs mock-rf-api >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+echo ""
+echo "Environment ready:"
+echo "  FPP web UI / API:    http://127.0.0.1:18080"
+echo "  Mock RF API:         http://127.0.0.1:18081"
+echo "  State directory:     $HERE/.state/"

--- a/fpp-test-env/scripts/start-listener.sh
+++ b/fpp-test-env/scripts/start-listener.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Convenience wrapper: run the plugin's postStart.sh inside the FPP container.
+# Useful for interactive sessions where you don't want to remember the
+# full `docker exec` invocation.
+#
+# Usage: start-listener.sh [PLUGIN_NAME]
+#   PLUGIN_NAME defaults to "remote-falcon".
+
+set -euo pipefail
+
+PLUGIN_NAME="${1:-remote-falcon}"
+CONTAINER="rf-test-fpp"
+
+if ! docker ps --filter "name=^${CONTAINER}$" --format '{{.Names}}' | grep -q "$CONTAINER"; then
+    echo "Container $CONTAINER is not running. Run scripts/spin-up.sh first." >&2
+    exit 1
+fi
+
+POSTSTART="/home/fpp/media/plugins/${PLUGIN_NAME}/scripts/postStart.sh"
+if ! docker exec "$CONTAINER" test -x "$POSTSTART"; then
+    echo "$POSTSTART not found or not executable inside the container." >&2
+    echo "(Did you run scripts/install-plugin.sh first?)" >&2
+    exit 1
+fi
+
+docker exec "$CONTAINER" "$POSTSTART"
+sleep 1
+
+PIDFILE="/home/fpp/media/plugins/${PLUGIN_NAME}/remote_falcon_listener.pid"
+if docker exec "$CONTAINER" test -f "$PIDFILE"; then
+    PID=$(docker exec "$CONTAINER" cat "$PIDFILE")
+    echo "Listener started (pid $PID). Tail log with:"
+    echo "  docker exec rf-test-fpp tail -f /home/fpp/media/logs/${PLUGIN_NAME}-listener.log"
+else
+    echo "postStart.sh ran but no PID file appeared. Check container logs." >&2
+    exit 1
+fi

--- a/fpp-test-env/scripts/tear-down.sh
+++ b/fpp-test-env/scripts/tear-down.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Stop the virtual FPP + mock RF API and clean up state.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$HERE"
+
+docker compose down -v --remove-orphans
+rm -rf "$HERE/.state"
+echo "Torn down."


### PR DESCRIPTION
## Summary
- Adds `fpp-test-env/`, a Docker Compose harness pairing the
  official `falconchristmas/fpp:9.5.3` image with a configurable
  PHP mock of the Remote Falcon plugins API. Lets plugin developers
  install, exercise, and assert against a plugin without touching
  hardware or hitting the production RF backend.
- Updates the top-level README to document the new test environment
  and provide a brief index of the existing repo contents.

### Components added under `fpp-test-env/`
- `docker-compose.yaml` — pinned FPP image (port 18080) + mock RF API
  on a private network reachable from FPP as `http://mock-rf-api`
- `mock-rf-api/router.php` — `php -S` based mock with sensible
  per-route defaults, JSON config overrides, and full request
  recording for test assertions
- `scripts/spin-up.sh` — boots both containers, bypasses FPP's
  first-run setup wizard so the UI is immediately navigable
- `scripts/install-plugin.sh PATH NAME` — copies a plugin source
  tree into the container with correct ownership and runs its
  `fpp_install.sh`
- `scripts/seed-config.sh NAME KEY=VALUE...` — writes the plugin's
  INI config inside the container with proper urlencoding
- `scripts/start-listener.sh NAME` — runs the plugin's `postStart.sh`
  and reports the resulting PID
- `scripts/smoke-test.sh PATH` — runs a plugin-defined smoke script
  with `FPP_BASE_URL`, `MOCK_RF_INTERNAL_URL`, etc. in the env
- `scripts/tear-down.sh` — cleans up containers and state
- `README.md` — full usage docs

## Test plan
- [x] Validated end-to-end against `remote-falcon-plugin`:
      11/11 smoke checks pass in ~25s on a cached image
- [x] Verified spin-up bypasses the FPP first-run setup wizard
- [x] Verified clean tear-down (no orphan containers, state dir removed)