### PR TITLE
feat: repoint compose build contexts to remote-falcon-platform monorepo

### DIFF
--- a/do-ubuntu-droplet/docker-compose.yaml
+++ b/do-ubuntu-droplet/docker-compose.yaml
@@ -9,10 +9,11 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: root
   plugins-api:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-plugins-api.git
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main
+      dockerfile: apps/plugins-api/Dockerfile
       args:
         - MONGO_URI=mongodb://root:root@mongo:27017/remote-falcon?authSource=admin
-        - OTEL_OPTS=
+        - OTEL_URI=
     image: plugins-api
     restart: always
     ports:
@@ -25,9 +26,8 @@ services:
       - mongo
   control-panel:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-control-panel.git
-      args:
-        - OTEL_OPTS=
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main
+      dockerfile: apps/control-panel/Dockerfile
     image: control-panel
     restart: always
     ports:
@@ -51,7 +51,8 @@ services:
       - mongo
   viewer:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-viewer.git
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main
+      dockerfile: apps/viewer/Dockerfile
       args:
         - OTEL_URI=
         - MONGO_URI=mongodb://root:root@mongo:27017/remote-falcon?authSource=admin
@@ -67,7 +68,7 @@ services:
       - mongo
   ui:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-ui.git
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main:apps/ui
       args:
         - HOST_ENV=prod
         - VERSION=1.0.0

--- a/local-docker-compose/docker-compose.yaml
+++ b/local-docker-compose/docker-compose.yaml
@@ -9,10 +9,11 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: root
   plugins-api:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-plugins-api.git
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main
+      dockerfile: apps/plugins-api/Dockerfile
       args:
         - MONGO_URI=mongodb://root:root@mongo:27017/remote-falcon?authSource=admin
-        - OTEL_OPTS=
+        - OTEL_URI=
     restart: always
     ports:
       - "8083:8083"
@@ -24,9 +25,8 @@ services:
       - mongo
   control-panel:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-control-panel.git
-      args:
-        - OTEL_OPTS=
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main
+      dockerfile: apps/control-panel/Dockerfile
     restart: always
     ports:
       - "8081:8081"
@@ -49,7 +49,8 @@ services:
       - mongo
   viewer:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-viewer.git
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main
+      dockerfile: apps/viewer/Dockerfile
       args:
         - OTEL_URI=
         - MONGO_URI=mongodb://root:root@mongo:27017/remote-falcon?authSource=admin
@@ -64,7 +65,7 @@ services:
       - mongo
   ui:
     build:
-      context: https://github.com/Remote-Falcon/remote-falcon-ui.git
+      context: https://github.com/Remote-Falcon/remote-falcon-platform.git#main:apps/ui
       args:
         - HOST_ENV=local
         - VERSION=local


### PR DESCRIPTION
After Phase A6 of the consolidation plan, the 8 service repos are about to be archived (Phase A7). The two compose files here build images directly from the per-service repos via git URL contexts, which would break when those repos go read-only.

## What changed

Both \`do-ubuntu-droplet/docker-compose.yaml\` and \`local-docker-compose/docker-compose.yaml\`:

- **plugins-api / control-panel / viewer** — context flips to \`https://github.com/Remote-Falcon/remote-falcon-platform.git#main\` with explicit \`dockerfile: apps/<svc>/Dockerfile\`. These services need the full monorepo as build context because their Dockerfiles \`COPY libs/schema/\` for shared MongoDB schema.
- **ui** — context flips to \`https://github.com/Remote-Falcon/remote-falcon-platform.git#main:apps/ui\` (subdir context). UI has no libs/schema dependency, so the smaller subdir context is fine.

## Build-arg cleanup

Pre-existing mismatch: the old compose passed \`OTEL_OPTS=\` but the monorepo Dockerfiles take \`OTEL_URI\`. Same name was likely the convention in the per-service repo Dockerfiles long ago; the monorepo rewrite normalized to \`OTEL_URI\`.

- \`plugins-api\`: \`OTEL_OPTS=\` → \`OTEL_URI=\` (Quarkus opentelemetry collector endpoint; empty = no telemetry export, fine for self-host)
- \`control-panel\`: \`OTEL_OPTS=\` removed (monorepo Dockerfile declares zero ARGs)
- \`viewer\`: \`OTEL_URI=\` already correct

## Test plan
- [ ] \`cd local-docker-compose && docker compose build\` — all 4 services build cleanly from the monorepo
- [ ] \`docker compose up\` — full local stack comes up; sign up, log in, viewer page renders
- [ ] On a fresh DO droplet: \`cd do-ubuntu-droplet && docker compose build && docker compose up -d\` — same expectations